### PR TITLE
support for saving and loading pnets and vnets

### DIFF
--- a/settings/main.yaml
+++ b/settings/main.yaml
@@ -19,7 +19,11 @@ experiment:
   run_id: auto  # if auto: hostname-datatime
   num_simulations: 1
   save_root_dir: virne/
-  if_save_config: true
+  if_save_config: true 
+  if_save_pnet: false
+  if_save_vnet: false 
+  if_load_pnet: false
+  if_load_vnet: false 
 
 # For Network System
 system:

--- a/virne/core/environment.py
+++ b/virne/core/environment.py
@@ -93,9 +93,10 @@ class BaseEnvironment:
             self.logger.info(f'Temp save record in {self.recorder.temp_save_path}\n')
 
         self.v_nets_dataset_dir = get_v_nets_dataset_dir_from_setting(self.v_net_simulator.v_sim_setting)
-        if os.path.exists(self.v_nets_dataset_dir) and seed is not None:
-            self.v_net_simulator = self.v_net_simulator.load_dataset(self.v_nets_dataset_dir)
-            self.logger.critical(f'Virtual networks: Load them from {self.v_nets_dataset_dir}')
+        v_net_dir= os.path.join( self.config.experiment.save_root_dir, self.v_nets_dataset_dir )
+        if os.path.exists(v_net_dir) and seed is not None and self.config.experiment.if_load_vnet:
+            self.v_net_simulator = self.v_net_simulator.load_dataset(v_net_dir, self.v_net_simulator.v_sim_setting)
+            self.logger.critical(f'Virtual networks: Load them from {v_net_dir}')
         else: 
             self.v_net_simulator.renew(v_nets=True, events=True, seed=seed)
             self.logger.critical(f'Virtual networks: Generate them with seed {seed}')

--- a/virne/network/physical_network.py
+++ b/virne/network/physical_network.py
@@ -219,6 +219,10 @@ class PhysicalNetwork(BaseNetwork):
     #         np.random.seed(seed)
     #     return net_instance
 
+    def to_gml(self, fpath):
+        gml_graph = self._prepare_gml_graph()
+        nx.write_gml(gml_graph, fpath)
+        
     def save_dataset(self, dataset_dir: str) -> None:
         """
         Saves the current physical network (topology and attributes) to a GML file.
@@ -269,7 +273,7 @@ class PhysicalNetwork(BaseNetwork):
             p_net.link_attr_benchmarks = p_net.get_link_attr_benchmarks()
             p_net.link_sum_attr_benchmarks = p_net.get_link_sum_attr_benchmarks()
             
-        print(f"Physical network dataset loaded from: {file_path}")
+        #print(f"Physical network dataset loaded from: {file_path}")
         return p_net
 
 # Example usage (optional, for testing or demonstration)

--- a/virne/network/virtual_network.py
+++ b/virne/network/virtual_network.py
@@ -6,6 +6,7 @@
 from functools import cached_property
 import numpy as np
 from typing import Any, List, Optional
+import networkx as nx
 
 from virne.network.base_network import BaseNetwork
 from virne.network.attribute import BaseAttribute
@@ -39,6 +40,17 @@ class VirtualNetwork(BaseNetwork):
         """Generates a virtual network topology."""
         super().generate_topology(num_nodes, type=type, **kwargs)
 
+    def to_gml(self, fpath):
+        gml_graph = self._prepare_gml_graph()
+
+        # vnet specfic metadata: only if defined
+        for key in ['id', 'arrival_time', 'lifetime', 'num_nodes', 'type']:
+            val = getattr(self, key, None)
+            if val is not None:
+                gml_graph.graph[key] = val
+
+        nx.write_gml(gml_graph, fpath)
+        
     @property
     def total_node_resource_demand(self) -> float:
         """Calculates the total resource demand of all nodes in the virtual network."""

--- a/virne/utils/network.py
+++ b/virne/utils/network.py
@@ -82,3 +82,24 @@ def flatten_recurrent_dict(recurrent_dict):
             raise ValueError('Unsupported types')
         else:
             pass
+
+def flatten_dict_list_for_gml(dicts):
+    """
+    Converts a list of dictionaries into a format safe for NetworkX GML:
+    - Each dict must have str keys and str/int/float values
+    - Returns list of cleaned dicts suitable for GML repeated keys
+    """
+    clean_list = []
+    for d in dicts:
+        flat = {str(k): str(v) for k, v in d.items()}
+        clean_list.append(flat)
+    return clean_list
+
+def sanitize_attr_setting(attrs):
+    """ Cast string values read in from GML file to ints """
+    for entry in attrs:
+        if "low" in entry:
+            entry["low"] = int(entry["low"])
+        if "high" in entry:
+            entry["high"] = int(entry["high"])
+    return attrs


### PR DESCRIPTION
Hey @GeminiLight ,

Congrats on releasing version 1.0!  It looks really good and is very clean. One thing that's been helpful for me is being able to save and load p_net.gml, v_net.gml files so I can better debug and investigate. 

In the PR, I added config variables in main.yaml to allow for that. They do:
  if_save_pnet: if true, save pnet to the save_root_dir under the generated name.
  if_save_vnet: if true, save the vnets to the  save_root_dir under the generated name
  if_load_pnet: if true, load the pnet from the save root with the generated name
  if_load_vnet: if true, load the vnet from the save root with the generated name
  
 Load vnet is cached after the first run so that for the following runs it is not regenerated. Also, since the vnet is generated on reset I figured maybe it might be useful to save only the first generated vnet. Not sure if this is what you had in mind for how a save/load flow would look like, but that seemed most practical to me.

I tried to keep the changes minimal and non-intrusive.  Let me know if this seems useful and I’m happy to make updates :)