### PR TITLE
feat(rank): add TOPSIS-based node ranking for VNE

### DIFF
--- a/docs/source/solver/overview.md
+++ b/docs/source/solver/overview.md
@@ -70,13 +70,14 @@
 
 ## Heuristics-based Solvers
 
-| Name                           | Command       | Type         | Mapping      | Title                                                        | Publication | Year | Note |
-| ------------------------------ | ------------- | ------------ | ------------ | ------------------------------------------------------------ | ----------- | ---- | ---- |
-| PL (Priority of Location)      | `pl_rank`     | `heuristics` | `two-stage`  | [Efficient Virtual Network Embedding of Cloud-Based Data Center Networks into Optical Networks](https://ieeexplore.ieee.org/document/9415134) | TPDS        | 2021 |      |
-| NRM (Node Resource Management) | `nrm_rank`    | `heuristics` | `two-stage`  | [Virtual Network Embedding Based on Computing, Network, and Storage Resource Constraints](https://ieeexplore.ieee.org/document/7976281) | IoTJ        | 2018 |      |
-| GRC (Global resource capacity) | `grc_rank`    | `heuristics` | `two-stage`  | [Toward Profit-Seeking Virtual Network Embedding Algorithm via Global Resource Capacity](https://ieeexplore.ieee.org/document/6847918) | INFOCOM     | 2014 |      |
-| RW-MaxMatch (NodeRank)         | `rw_rank`     | `heuristics` | `two-stage`  | [Virtual Network Embedding Through Topology-Aware Node Ranking](https://dl.acm.org/doi/10.1145/1971162.1971168) | ACM SIGCOMM Computer Communication Review     | 2011 |      |
-| RW-BFS (NodeRank)              | `rw_rank_bfs` | `heuristics` | `bfs_trials` | [Virtual Network Embedding Through Topology-Aware Node Ranking](https://dl.acm.org/doi/10.1145/1971162.1971168) | ACM SIGCOMM Computer Communication Review     | 2011 |      |
+| Name                           | Command        | Type         | Mapping      | Title                                                        | Publication | Year | Note |
+| ------------------------------ | -------------- | ------------ | ------------ | ------------------------------------------------------------ | ----------- | ---- | ---- |
+| PL (Priority of Location)      | `pl_rank`      | `heuristics` | `two-stage`  | [Efficient Virtual Network Embedding of Cloud-Based Data Center Networks into Optical Networks](https://ieeexplore.ieee.org/document/9415134) | TPDS        | 2021 |      |
+| NRM (Node Resource Management) | `nrm_rank`     | `heuristics` | `two-stage`  | [Virtual Network Embedding Based on Computing, Network, and Storage Resource Constraints](https://ieeexplore.ieee.org/document/7976281) | IoTJ        | 2018 |      |
+| GRC (Global resource capacity) | `grc_rank`     | `heuristics` | `two-stage`  | [Toward Profit-Seeking Virtual Network Embedding Algorithm via Global Resource Capacity](https://ieeexplore.ieee.org/document/6847918) | INFOCOM     | 2014 |      |
+| RW-MaxMatch (NodeRank)         | `rw_rank`      | `heuristics` | `two-stage`  | [Virtual Network Embedding Through Topology-Aware Node Ranking](https://dl.acm.org/doi/10.1145/1971162.1971168) | ACM SIGCOMM Computer Communication Review     | 2011 |      |
+| RW-BFS (NodeRank)              | `rw_rank_bfs`  | `heuristics` | `bfs_trials` | [Virtual Network Embedding Through Topology-Aware Node Ranking](https://dl.acm.org/doi/10.1145/1971162.1971168) | ACM SIGCOMM Computer Communication Review     | 2011 |      |
+| TOPSIS (Node Ranking)          | `topsis_rank`  | `heuristics` | `two-stage`  | [Network Function Virtualization (NFV) for Flexible Network Services by Using TOPSIS Method](https://computerscience.theappliedscience.org) | Computer Science, Engineering and Technology | 2024 |      |
 
 ## Exact Solvers
 

--- a/virne/solver/heuristic/node_rank.py
+++ b/virne/solver/heuristic/node_rank.py
@@ -370,5 +370,29 @@ class RandomWalkRankSolver(BaseNodeRankSolver):
     #     return True if link_mapping_result else False
 
 
+@SolverRegistry.register(solver_name='topsis_rank',
+    solver_type='node_ranking')
+class TOPSISRankSolver(BaseNodeRankSolver):
+    """
+    A node ranking-based solver that uses TOPSIS (Technique for Order of
+    Preference by Similarity to Ideal Solution) to rank substrate nodes.
+
+    Node and link resource attributes serve as TOPSIS decision criteria.
+    Each substrate node is scored by its closeness coefficient — how close
+    it is to the ideal resource profile — and virtual nodes are placed onto
+    the highest-scoring substrate nodes first.
+
+    References:
+        - Paladugu, N., Das, D., Nagalla, S. (2024). "Network Function
+          Virtualization (NFV) for Flexible Network Services by Using TOPSIS
+          Method." Computer Science, Engineering and Technology, 2(2), 44–51.
+    """
+
+    def __init__(self, controller: Controller, recorder: Recorder, counter: Counter, logger: Logger, config, **kwargs) -> None:
+        super(TOPSISRankSolver, self).__init__(controller, recorder, counter, logger, config, **kwargs)
+        self.node_rank = TOPSISNodeRank()
+        self.link_rank = None
+
+
 if __name__ == '__main__':
     pass

--- a/virne/solver/rank/node_rank.py
+++ b/virne/solver/rank/node_rank.py
@@ -231,6 +231,63 @@ class RWNodeRank(NodeRank):
         return self.to_dict(network, nr, sort=sort)
 
 
+@NodeRankRegistry.register('topsis')
+class TOPSISNodeRank(NodeRank):
+    """
+    Ranks substrate nodes using TOPSIS (Technique for Order of Preference
+    by Similarity to Ideal Solution).
+
+    Each node is treated as an alternative whose decision criteria are its
+    available resource attributes (e.g. CPU, memory) concatenated with the
+    aggregate available bandwidth of its incident links.  The closeness
+    coefficient of each node — measuring its relative proximity to the
+    ideal solution — becomes its ranking score.  Nodes with higher scores
+    are preferred for virtual node placement.
+
+    All criteria are treated as benefit criteria (higher is better), and
+    equal weights are applied across all resource dimensions.
+    """
+
+    def rank(self, network: BaseNetwork, sort: bool = True) -> Dict[Any, float]:
+        node_attrs = network.get_node_attrs('resource')
+        node_data = np.array(network.get_node_attrs_data(node_attrs), dtype=float).T
+
+        link_attrs = network.get_link_attrs('resource')
+        link_agg = np.array(
+            network.get_aggregation_attrs_data(link_attrs, aggr='sum', normalized=False),
+            dtype=float,
+        ).T
+
+        if node_data.ndim == 1:
+            node_data = node_data.reshape(-1, 1)
+        if link_agg.ndim == 1:
+            link_agg = link_agg.reshape(-1, 1)
+
+        decision_matrix = np.hstack([node_data, link_agg])
+
+        # Normalise column-wise using the Euclidean norm
+        col_norms = np.sqrt((decision_matrix ** 2).sum(axis=0))
+        col_norms[col_norms == 0] = 1.0
+        normalized = decision_matrix / col_norms
+
+        # Equal weights across all criteria
+        num_criteria = normalized.shape[1]
+        weights = np.ones(num_criteria) / num_criteria
+        weighted = normalized * weights
+
+        # All resource criteria are benefit-type (higher is better)
+        ideal_pos = weighted.max(axis=0)
+        ideal_neg = weighted.min(axis=0)
+
+        dist_pos = np.sqrt(((weighted - ideal_pos) ** 2).sum(axis=1))
+        dist_neg = np.sqrt(((weighted - ideal_neg) ** 2).sum(axis=1))
+
+        # Closeness coefficient: 1 = ideal, 0 = anti-ideal
+        closeness = dist_neg / (dist_pos + dist_neg + 1e-9)
+
+        return self.to_dict(network, closeness, sort=sort)
+
+
 @NodeRankRegistry.register('nps')
 class NPSNodeRank(NodeRank):
     """Ranks nodes using Node Proximity Sensing (NPS) metric."""


### PR DESCRIPTION
## Summary

Adds a TOPSIS (Technique for Order of Preference by Similarity to Ideal Solution) node ranking algorithm and its corresponding two-stage solver to Virne.

### What changes

**`virne/solver/rank/node_rank.py`** — new `TOPSISNodeRank` class registered as `'topsis'`:
- Builds a decision matrix whose rows are substrate nodes and whose columns are their available resource attributes (CPU, memory, …) concatenated with the aggregate available bandwidth of each node's incident links.
- Euclidean-normalises each column, applies equal weights (all criteria are benefit-type), then computes TOPSIS positive and negative ideal solutions.
- Scores each node by its closeness coefficient `dist_neg / (dist_pos + dist_neg)`. Nodes closest to the ideal resource profile receive the highest score and are placed first during VNE.

**`virne/solver/heuristic/node_rank.py`** — new `TOPSISRankSolver` registered as `'topsis_rank'`:
- Wraps `TOPSISNodeRank` inside the existing `BaseNodeRankSolver` two-stage pipeline.
- Invoked with `python main.py solver.solver_name=topsis_rank`.

**`docs/source/solver/overview.md`** — adds `topsis_rank` row to the heuristics solver table.

### Motivation

TOPSIS is a well-established MCDM method for multi-criteria node selection that provides a principled distance-to-ideal scoring without requiring iterative convergence (unlike GRC or RW). It naturally handles heterogeneous resource dimensions and produces scores in `[0, 1]` that are directly interpretable as embedding priority.